### PR TITLE
First version of the monitoring API

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -197,7 +197,7 @@ Entries
       "time": 1405773742.817528
     }
 
-.. http:get:: /entries/(name)/stop
+.. http:put:: /entries/(name)/stop
 
   Stop a given entry.
 
@@ -205,7 +205,7 @@ Entries
 
   .. sourcecode:: http
 
-    GET /api/v1/entries/A/stop HTTP/1.1
+    PUT /api/v1/entries/A/stop HTTP/1.1
     Host: 127.0.0.1
     Accept: application/json
 
@@ -221,7 +221,7 @@ Entries
       "status": "ok"
     }
 
-.. http:get:: /entries/(name)/start
+.. http:put:: /entries/(name)/start
 
   Start a given entry.
 
@@ -229,7 +229,7 @@ Entries
 
   .. sourcecode:: http
 
-    GET /api/v1/entries/A/start HTTP/1.1
+    PUT /api/v1/entries/A/start HTTP/1.1
     Host: 127.0.0.1
     Accept: application/json
 
@@ -245,7 +245,7 @@ Entries
       "status": "ok"
     }
 
-.. http:get:: /entries/(name)/restart
+.. http:put:: /entries/(name)/restart
 
   Stop and start a given entry.
 
@@ -253,7 +253,7 @@ Entries
 
   .. sourcecode:: http
 
-    GET /api/v1/entries/A/restart HTTP/1.1
+    PUT /api/v1/entries/A/restart HTTP/1.1
     Host: 127.0.0.1
     Accept: application/json
 
@@ -342,7 +342,7 @@ Rules
       "status": "ok"
     }
 
-.. http:get:: /rules/reload
+.. http:put:: /rules/reload
 
   Apply the rules (if they changed since the last time)
 
@@ -350,7 +350,7 @@ Rules
 
   .. sourcecode:: http
 
-    GET /api/v1/rules/reload HTTP/1.1
+    PUT /api/v1/rules/reload HTTP/1.1
     Host: 127.0.0.1
     Accept: application/json
 

--- a/onitu/api/__main__.py
+++ b/onitu/api/__main__.py
@@ -93,7 +93,7 @@ def get_entry_stats(name):
         stats = circus_client.call(query)
     else:
         stats = {
-            "stats": "error",
+            "status": "error",
             "reason": "entry {} not found".format(name)
         }
     return stats

--- a/onitu/api/__main__.py
+++ b/onitu/api/__main__.py
@@ -118,7 +118,7 @@ def get_entry_status(name):
     return status
 
 
-@app.route('/api/v1.0/entries/<name>/start', method='GET')
+@app.route('/api/v1.0/entries/<name>/start', method='PUT')
 def start_entry(name):
     name = name.upper()
     if entry_exist(name):
@@ -138,7 +138,7 @@ def start_entry(name):
     return response
 
 
-@app.route('/api/v1.0/entries/<name>/stop', method='GET')
+@app.route('/api/v1.0/entries/<name>/stop', method='PUT')
 def stop_entry(name):
     name = name.upper()
     if entry_exist(name):
@@ -158,7 +158,7 @@ def stop_entry(name):
     return response
 
 
-@app.route('/api/v1.0/entries/<name>/restart', method='GET')
+@app.route('/api/v1.0/entries/<name>/restart', method='PUT')
 def restart_entry(name):
     name = name.upper()
     if entry_exist(name):


### PR DESCRIPTION
Add the routes:

```
- /entries/<name>/stats
- /entries/<name>/status
- /entries/<name>/start
- /entries/<name>/stop
- /entries/<name>/restart
```

Please don't merge this pull request right now, it needs to be improved.

I wonder what we should do when someone try to stop an already stopped entry (same thing for the start, stats, …). Right now, I just send "OK". Should I change the response?

How should I test the API?
