### PR TITLE
Added a mimetypes field to the data returned by the server on a regular /files request

### DIFF
--- a/onitu/plug/metadata.py
+++ b/onitu/plug/metadata.py
@@ -1,6 +1,7 @@
 
 from onitu.utils import get_fid, get_mimetype
 
+
 class Metadata(object):
     """The Metadata class represent the metadata of any file in Onitu.
 

--- a/onitu/plug/metadata.py
+++ b/onitu/plug/metadata.py
@@ -1,5 +1,5 @@
-from onitu.utils import get_fid
 
+from onitu.utils import get_fid, get_mimetype
 
 class Metadata(object):
     """The Metadata class represent the metadata of any file in Onitu.
@@ -21,6 +21,8 @@ class Metadata(object):
         The entries which should have this file
     **uptodate**
         The entries with an up-to-date version of this file
+    **mimetype**
+        The MIME type of the file, as detected by python
 
     Each entry can also store extra informations via the :attr:`.extra`
     attribute. It's a dictionary which can contain any kind of information,
@@ -29,21 +31,25 @@ class Metadata(object):
     are stocked separately.
     """
 
-    PROPERTIES = ('filename', 'size', 'owners', 'uptodate')
+    PROPERTIES = ('filename', 'size', 'owners', 'uptodate', 'mimetype')
 
     def __init__(self, plug=None, filename=None, size=0,
-                 fid=None, owners=[], uptodate=[]):
+                 fid=None, owners=[], uptodate=[], mimetype=None):
         super(Metadata, self).__init__()
 
         self.filename = filename
         self.size = size
         self.owners = owners
         self.uptodate = uptodate
+        self.mimetype = mimetype
 
         if not fid and filename:
             self.fid = get_fid(filename)
         elif fid:
             self.fid = fid
+
+        if not self.mimetype and filename:
+            self.mimetype = get_mimetype(filename)
 
         self.extra = {}
 

--- a/onitu/utils.py
+++ b/onitu/utils.py
@@ -68,8 +68,6 @@ def get_mimetype(filename):
     if not mimetype:
         mimetype = 'application/octet-stream'
 
-    print(mimetype)
-
     return mimetype
 
 

--- a/onitu/utils.py
+++ b/onitu/utils.py
@@ -62,15 +62,16 @@ def get_mimetype(filename):
 
     mimetype = mimetypes.guess_type(filename)[0]
 
-    ## RFC 2046 states in section 4.5.1:
-    ## The "octet-stream" subtype is used to indicate that a body contains
-    ## arbitrary binary data.
+    # RFC 2046 states in section 4.5.1:
+    # The "octet-stream" subtype is used to indicate that a body contains
+    # arbitrary binary data.
     if not mimetype:
         mimetype = 'application/octet-stream'
 
-    print mimetype
+    print(mimetype)
 
     return mimetype
+
 
 def get_open_port():
     """

--- a/onitu/utils.py
+++ b/onitu/utils.py
@@ -8,6 +8,7 @@ import uuid
 import signal
 import socket
 import tempfile
+import mimetypes
 
 PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
@@ -50,6 +51,26 @@ def get_fid(filename):
 
     return str(uuid.uuid5(NAMESPACE_ONITU, filename))
 
+
+def get_mimetype(filename):
+    """
+    Get the MIME type of the given filename.
+
+    This avoids interfaces and clients of the Onitu instances having to
+    determine the MIME type of the files they receive notifications from.
+    """
+
+    mimetype = mimetypes.guess_type(filename)[0]
+
+    ## RFC 2046 states in section 4.5.1:
+    ## The "octet-stream" subtype is used to indicate that a body contains
+    ## arbitrary binary data.
+    if not mimetype:
+        mimetype = 'application/octet-stream'
+
+    print mimetype
+
+    return mimetype
 
 def get_open_port():
     """


### PR DESCRIPTION
This commit adds a new field to the data returned by Onitu when the files list is being queried. This allows frontends to leverage the load of determining the MIME type of the files on the server.
