### PR TITLE
Watch each folder instead of the root

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -37,7 +37,7 @@ mode
      :w (write):
 	If not specified new files or changes will not be written to this folder. You must specify this if you want Onitu to make changes to this folder when syncronising.
 
-type
+mimetypes
   :values:
      To be defined. One or more media types as defined in rfc6838. Incomplete types such as "example/*" instead of "example/media_type", 'example/predicate.*' or '*/example' are be accepted.
   :default:

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -122,6 +122,14 @@ At this stage, the list of the handlers that can be defined is the following :
   perturbations.
 
 
+.. function:: normalize_path(path)
+
+    Called when a folder is initialized. This handler should normalize the given path to make sure it will be valid when used latter on.
+    For example it can expand the user directory (`~/`) or remove trailing slashes, according to the needs and possibilities of the service.
+
+    :param path: The path to normalize.
+    :type path: string
+
 The Plug
 ========
 

--- a/drivers/amazon_s3/README
+++ b/drivers/amazon_s3/README
@@ -12,24 +12,44 @@ To make it work you're going to need your Amazon Access ID and your Amazon Secre
 
 If you already have an AWS account, you can retrieve them at https://console.aws.amazon.com/iam/home?#security_credential, tab "Access Keys (Access Key ID and Secret Access Key)".
 
-Once you have them, you need to create a new driver service in the setup JSON file (setup.json), and fill in the following fields:
-- driver : this should always be "amazon_s3"
-- options: The following options can be used:
+Once you have them, you need to create a new driver service called "amazon_s3" in the setup YAML file (setup.yml), and fill in the following options fields:
   - bucket: the name of the bucket you want to use with Onitu
-  - root: The folder under which you want Onitu to put all the transferred files on your bucket. Onitu won't put files elsewhere. If you want to use the whole bucket, omit it or set ""
   - aws_access_key: Put here your AWS Access Key
   - aws_secret_key: Put here your AWS Secret Key
   - changes_timer: Onitu periodically checks for changes on the bucket. Use this to set a period of time, in seconds, between each retry. Defaults to 10 seconds if you omit it
 
-A correct syntax for the service could be the following:
+Here is a sample configuration to synchronize a local folder and a folder on your Amazon S3:
 
-    "s3": {
-      "driver": "amazon_s3",
-	  "root": "/onitu",
-      "options": {
-	"bucket": "onitu-test-2",
-	"aws_access_key": "YourAccessKey",
-	"aws_secret_key": "YourSecretKey",
-	"changes_timer" : 10
-       }
-     }
+"
+name: example
+
+folders:
+  music:
+    mimetypes:
+      - "audio/*"
+  docs:
+    blacklist:
+      - "*.bak" 
+      - Private/
+  backup:
+    blacklist:
+      - ".*"
+    file_size:
+      max: 2G
+
+services:
+  A:
+    driver: local_storage 
+    folders:
+      music: /home/baron_a/Music
+      docs: /home/baron_a/Docs
+  S:  
+    driver: amazon_s3
+    folders:
+       music: pando/music/
+    options:
+        bucket: onitu-test-2
+        aws_access_key: AKIAJSWLJPXBXENIPIZQ
+        aws_secret_key: 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
+        changes_timer : 10
+"

--- a/drivers/amazon_s3/onitu_amazon_s3/amazon_s3.py
+++ b/drivers/amazon_s3/onitu_amazon_s3/amazon_s3.py
@@ -54,23 +54,14 @@ def get_conn():
             err += u": Invalid credentials."
         err += u" Please check your Amazon S3 configuration - {}".format(httpe)
         raise DriverError(err)
+    plug.logger.debug("Connection with Amazon S3 account successful")
     return S3Conn
-
-
-def get_root():
-    """Returns Onitu's root for S3. Removes the leading slash if any."""
-    root = plug.root
-    if root.startswith(u'/'):  # S3 doesn't like leading slashes
-        root = root[1:]
-    return root
 
 
 def get_file_timestamp(filename):
     """Returns the float timestamp based on the
     date format timestamp stored by Amazon.
     Prefixes the given filename with Onitu's root."""
-    global S3Conn
-
     metadata = S3Conn.head_object(u(filename))
     timestamp = metadata.headers['last-modified']
     # convert timestamp to timestruct...
@@ -83,8 +74,6 @@ def get_file_timestamp(filename):
 def add_to_cache(multipart_upload):
     """Caches a multipart upload. Checks that the cache isn't growing
     past MAX_CACHE_SIZE and that it isn't in the cache yet."""
-    global cache
-
     if len(cache) < MAX_CACHE_SIZE:
         if multipart_upload.uploadId not in cache:
             cache[multipart_upload.uploadId] = multipart_upload
@@ -92,8 +81,6 @@ def add_to_cache(multipart_upload):
 
 def remove_from_cache(multipart_upload):
     """Removes the given MultipartUpload from the cache, if in it."""
-    global cache
-
     if multipart_upload.uploadId in cache:
         del cache[multipart_upload.uploadId]
 
@@ -102,9 +89,6 @@ def get_multipart_upload(metadata):
     """Returns the multipart upload we have the ID of in metadata.
     As Amazon allows several multipart uploads at the same time
     for the same file, the ID is the only unique, reliable descriptor."""
-    global S3Conn
-    global cache
-
     multipart_upload = None
     metadata_mp_id = None
     filename = metadata.path
@@ -142,12 +126,7 @@ def set_chunk_size(chunk_size):
 
 @plug.handler()
 def get_chunk(metadata, offset, size):
-    global S3Conn
-    global plug
-
     filename = metadata.path
-    plug.logger.debug(u"GET CHUNK {} {} {}".format(filename, offset,
-                                                   size))
     plug.logger.debug(u"Downloading {} bytes from the {} key"
                       u" on bucket {}".format(size, filename,
                                               plug.options['bucket']))
@@ -197,9 +176,6 @@ def upload_chunk(metadata, offset, chunk):
 
 @plug.handler()
 def start_upload(metadata):
-    global S3Conn
-    global plug
-
     filename = metadata.path
     plug.logger.debug(u"Starting upload of '{}' to '{}' on bucket {}"
                       .format(filename, filename,
@@ -222,8 +198,6 @@ def start_upload(metadata):
 
 @plug.handler()
 def upload_file(metadata, data):
-    global S3Conn
-    global plug
     filename = metadata.path
     plug.logger.debug(u"Starting one-shot upload of '{}' on bucket {}"
                       .format(filename, plug.options['bucket']))
@@ -239,8 +213,6 @@ def upload_file(metadata, data):
 
 @plug.handler()
 def end_upload(metadata):
-    global S3Conn
-
     multipart_upload = get_multipart_upload(metadata)
     filename = metadata.path
     # Finish the upload on remote server before getting rid of the
@@ -284,8 +256,6 @@ def abort_upload(metadata):
 
 @plug.handler()
 def move_file(old_metadata, new_metadata):
-    global plug
-    global S3Conn
     old_filename = old_metadata.path
     new_filename = new_metadata.path
     bucket = plug.options['bucket']
@@ -316,8 +286,6 @@ def move_file(old_metadata, new_metadata):
 
 @plug.handler()
 def delete_file(metadata):
-    global plug
-    global S3Conn
     try:
         filename = metadata.path
         plug.logger.debug(u"Deleting {} "
@@ -338,34 +306,23 @@ class CheckChanges(threading.Thread):
     we can do is periodically polling the bucket's contents and compare the
     timestamps."""
 
-    def __init__(self, timer):
+    def __init__(self, folder, timer):
         threading.Thread.__init__(self)
-        self.stop = threading.Event()
+        self.stopEvent = threading.Event()
         self.timer = timer
+        self.prefix = folder.path
 
     def check_bucket(self):
-        global S3Conn
-        global plug
-
-        plug.logger.debug(u"Checking bucket"
-                          u" {} for changes".format(plug.options['bucket']))
-        # We're only interested in keys and uploads under Onitu's root
-        root = get_root()
-        # We add a trailing slash to only list files under root and not the
-        # root itself
-        if not root.endswith(u'/'):
-            root += u'/'
+        folder = self.prefix  # Folder name, e.g. "pando/music/"
+        plug.logger.debug(u"Checking folder"
+                          u" {} for changes".format(folder))
         # We need to unroll the generator to be able to check for folders
-        keys = [key for key in S3Conn.list(prefix=root)]
-        plug.logger.debug(u"Processing files under '{}'".format(root))
-        # Getting multipart uploads once for all files under root
+        keys = [key for key in S3Conn.list(prefix=folder)]
+        plug.logger.debug(u"Processing files under '{}'".format(folder))
+        # Getting multipart uploads once for all files under this folder
         # is WAY faster than re-getting them for each file
-        multipart_uploads = S3Conn.get_all_multipart_uploads(prefix=root)
+        multipart_uploads = S3Conn.get_all_multipart_uploads(prefix=folder)
         keys_being_uploaded = [mp.key for mp in multipart_uploads]
-        # We have to be extra careful because S3 will list filenames without
-        # leading slash.
-        if root.startswith('/'):
-            root = root[1:]
         for key in keys:
             plug.logger.debug(u"Processing file '{}'".format(key['key']))
             # During an upload, files can appear on the S3 file system
@@ -380,7 +337,7 @@ class CheckChanges(threading.Thread):
             # regular files. If a file is empty, check if other files begin
             # by its name (meaning it contains them)
             if key['size'] == 0:
-                prefix = key['key'] + '/'
+                prefix = key['key'] + "/"
                 children = [child for child in keys
                             if child['key'].startswith(prefix)]
                 if children:
@@ -388,8 +345,7 @@ class CheckChanges(threading.Thread):
                                       u" - skipped".format(key['key']))
                     continue
             # Strip the S3 root of the S3 filename for root coherence.
-            rootless_key = key['key'][len(root):]
-            metadata = plug.get_metadata(rootless_key)
+            metadata = plug.get_metadata(key['key'])
             onitu_ts = metadata.extra.get('timestamp', 0.0)
             remote_ts = time.mktime(key['last_modified'].timetuple())
             if onitu_ts < remote_ts:  # Remote timestamp is more recent
@@ -402,15 +358,13 @@ class CheckChanges(threading.Thread):
                           .format(self.timer))
 
     def run(self):
-        global plug
-
-        while not self.stop.isSet():
+        while not self.stopEvent.isSet():
             try:
                 self.check_bucket()
             except requests.HTTPError as httpe:
-                err = u"Error while polling Onitu's S3 bucket"
+                err = u"Error while polling Onitu's S3 bucket:"
                 if httpe.response.status_code == 404:
-                    err += u": The given bucket {} doesn't exist".format(
+                    err += u" The given bucket {} doesn't exist".format(
                         plug.options['bucket'])
                 err += u" - {}".format(httpe)
                 plug.logger.error(err)
@@ -418,11 +372,10 @@ class CheckChanges(threading.Thread):
                 err = u"Failed to connect to Onitu's S3 bucket for polling"
                 err += u" - {}".format(conne)
                 plug.logger.error(err)
-            # if the bucket read operation times out
+            # if the bucket read operation times out, cannot do much about it
             except SSLError as ssle:
                 plug.logger.warning(u"Couldn't poll S3 bucket '{}': {}"
                                     .format(plug.options['bucket'], ssle))
-                pass  # cannot do much about it
             # Happens when connection is reset by peer
             except socket.error as serr:
                 plug.logger.warning(u"Network problem, trying to reconnect. "
@@ -431,44 +384,45 @@ class CheckChanges(threading.Thread):
             except EscalatorClosed:
                 # We are closing
                 return
-            self.stop.wait(self.timer)
+            self.stopEvent.wait(self.timer)
 
     def stop(self):
-        self.stop.set()
+        self.stopEvent.set()
 
 
 def start():
-    global S3Conn
-
     if plug.options['changes_timer'] < 0:
         raise DriverError(
             u"The change timer option must be a positive integer")
     get_conn()  # connection to S3
-    root = get_root()
-    if root != '':
-        # Check that the given root isn't a regular file
+    for folder in plug.folders_to_watch:
+        if folder.path.startswith(u"/") or not folder.path.endswith(u"/"):
+            raise DriverError(u"S3 folders name must have no leading slash"
+                              u" and must end with a trailing slash (folder"
+                              u" name {} is invalid)".format(folder.path))
+        # Check that the given folder isn't a regular file
         try:
-            root_key = S3Conn.get(root)
+            folder_key = S3Conn.get(folder.path)
         except requests.HTTPError as httpe:
             if httpe.response.status_code == 404:
                 # it's alright, root doesn't exist, no problem
                 pass
             else:  # another error
-                raise DriverError(u"Cannot fetch Onitu's root ({}) on"
-                                  u" bucket "
-                                  u"{}: {}".format(plug.root,
-                                                   plug.options['bucket'],
-                                                   httpe))
+                raise DriverError(u"Error while fetching folder '{}' on"
+                                  u" bucket {}: {}"
+                                  .format(folder.path,
+                                          plug.options['bucket'],
+                                          httpe))
         else:  # no error - root already exists
             # Amazon S3 has no concept of directories, they're just 0-size
             # files. So if root hasn't a size of 0, it is a regular file.
-            if len(root_key.content) != 0:
-                raise DriverError(
-                    u"Onitu's root ({}) is a regular file on the '{}' bucket. "
-                    u"It has to be an empty file.".format(
-                        plug.root, plug.options['bucket'])
-                    )
-    check = CheckChanges(plug.options['changes_timer'])
-    check.daemon = True
-    check.start()
+            if len(folder_key.content) != 0:
+                raise DriverError(u"Folder {} is a regular file on the"
+                                  u"'{}' bucket. Please delete it"
+                                  .format(folder.path,
+                                          plug.options['bucket']))
+        check = CheckChanges(folder, plug.options['changes_timer'])
+        check.daemon = True
+        check.start()
+
     plug.listen()

--- a/drivers/dropbox/README
+++ b/drivers/dropbox/README
@@ -4,8 +4,7 @@ Getting started with the Dropbox driver
 Run the get_access_token.py script in order to let Onitu gain access to your
 Dropbox account.
 
-Retrieve the access key and secret provided by the script and put it in
-Onitu's setup.json for Onitu to use it to authenticate itself with the Dropbox Core API.
+Retrieve the access key and secret provided by the script and put it in Onitu's configuration file for Onitu to use it to authenticate itself with the Dropbox Core API.
 
 Dropbox Driver
 ==============
@@ -20,21 +19,49 @@ Just run "python get_access_token.py" in a terminal, and go to the generated URL
 
 The script will then provide you an "Access Key" and an "Access Secret". They are the codes you'll need to use with Onitu.
 
-Once you have them, you need to create a new driver service in the setup JSON file (setup.json), and fill in the following fields:
-- driver : this should always be "dropbox"
-- options: The following options can be used:
-  - root: The folder under which you want Onitu to put all the transferred files on your Dropbox. Onitu won't put files elsewhere. If you want to use the whole Dropbox, omit it or set ""
+Once you have them, you need to create a new driver service in the setup YAML file (setup.yml). Create a new service using driver "dropbox", and fill the following
+fields in its "options" section:
   - access_key: Put here your Access Key
   - access_secret: Put here your Access Secret
-  - changes_timer: Onitu periodically checks for changes on Dropbox. Use this to set a period of time, in seconds, between each retry. Defaults to 1 minute (60 seconds) if you omit it.
+  - changes_timer: Onitu periodically checks for changes on Dropbox. Use this to set a period of time, in seconds, between each retry.
+    		   Defaults to 1 minute (60 seconds) if you omit it.
 
-A correct syntax for the service could be the following:
-    "dropbox": {
-      "driver": "dropbox",
-      "root": "onitu",
-      "options": {
-        "access_key": "YourAccessKey",
-        "access_secret": "YourAccessSecret",
-	"changes_timer" : 60
-      }
-    }
+Example
+=======
+
+This is an example YAML setup using a local storage driver and a Dropbox driver properly set up to share folders:
+"
+name: example
+
+folders:
+  music:
+    mimetypes:
+      - "audio/*"
+  docs:
+    blacklist:
+      - "*.bak"
+      - Private/
+  backup:
+    blacklist:
+      - ".*"
+    file_size:
+      max: 2G
+
+services:
+  A:
+    driver: local_storage
+    folders:
+      music: /home/baron_a/Music
+      docs: /home/baron_a/Docs
+  D:
+    driver: dropbox
+    folders:
+      music: /pando/Music
+      docs: /pando/Docs
+    options:
+        access_key: INSERT_ACCESS_KEY_HERE
+        access_secret: INSERT_ACCESS_SECRET_HERE
+        changes_timer: 10
+"
+
+It will synchronize the local folders /home/baron_a/Music and /home/baron_a/Docs with their Dropbox counterparts, /pando/Music and /pando/Docs.

--- a/drivers/dropbox/onitu_dropbox/dropbox_driver.py
+++ b/drivers/dropbox/onitu_dropbox/dropbox_driver.py
@@ -376,9 +376,11 @@ class CheckChanges(threading.Thread):
                 plug.logger.debug(u"{} is a folder - skipped"
                                   .format(db_metadata['path']))
                 continue
+            # Strip the folder prefix of the filename
+            filename = filename[len(self.prefix):]
             plug.logger.debug(u"Getting metadata of file '{}'"
                               .format(filename))
-            metadata = plug.get_metadata(filename)
+            metadata = plug.get_metadata(filename, folder=self.folder)
             # Do not check updates if the file has been deleted
             if self.file_deletion_check(metadata, db_metadata):
                 continue

--- a/drivers/dropbox/onitu_dropbox/dropbox_driver.py
+++ b/drivers/dropbox/onitu_dropbox/dropbox_driver.py
@@ -333,11 +333,10 @@ class CheckChanges(threading.Thread):
             plug.logger.debug(u"Onitu file '{}' is up-to-date"
                               .format(metadata.filename))
 
-    def is_a_folder(self, onitu_filename, db_metadata):
-        """Tells if a given Dropbox file is a folder based on its Onitu
-        filename and Dropbox metadata"""
-        # if onitu_filename = empty string: it's the root's file, ignore it
-        return onitu_filename == '' or db_metadata.get('is_dir', False)
+    def is_a_folder(self, db_metadata):
+        """Tells if a given Dropbox file is a folder based on
+        Dropbox metadata"""
+        return db_metadata.get('is_dir', False)
 
     def get_onitu_filename(self, db_path):
         """Given a Dropbox metadata dict, retrieve the matching Dropbox file
@@ -373,7 +372,7 @@ class CheckChanges(threading.Thread):
                 db_metadata['path']
             )
             # ignore directories as onitu creates them on the fly
-            if self.is_a_folder(filename, db_metadata):
+            if self.is_a_folder(db_metadata):
                 plug.logger.debug(u"{} is a folder - skipped"
                                   .format(db_metadata['path']))
                 continue

--- a/drivers/dropbox/onitu_dropbox/dropbox_driver.py
+++ b/drivers/dropbox/onitu_dropbox/dropbox_driver.py
@@ -269,26 +269,33 @@ class CheckChanges(threading.Thread):
     Dropbox with our current delta to know what has changed since we retrieved
     it."""
 
-    def __init__(self, timer):
+    def __init__(self, folder, timer):
         threading.Thread.__init__(self)
-        self.stop = threading.Event()
+        self.stopEvent = threading.Event()
+        self.folder = folder
         self.timer = timer
         # Cursors are used for Dropbox deltas to know from which point it must
         # send changes. A cursor is returned at each delta request, and one
         # ought to send the previous cursor to receive only the changes that
         # have occurred since the last time.
-        self.cursor = plug.service_db.get('dropbox_cursor', default=None)
+        self.cursorName = 'dropbox_cursor_{}'.format(self.folder.path)
+        self.cursor = plug.service_db.get(self.cursorName,
+                                          default=None)
         # The onitu root folder on Dropbox
-        self.prefix = plug.service_db.get('root',
-                                          default=u(plug.root))
-        plug.logger.debug("Getting cursor '{}' out of database"
-                          .format(self.cursor))
+        self.prefix = self.folder.path
+        if not self.prefix.startswith(u"/"):
+            self.prefix = u"/" + self.prefix
+        if not self.prefix.endswith(u"/"):
+            self.prefix = self.prefix + u"/"
+        plug.logger.debug("Getting {} value '{}' out of database"
+                          .format(self.cursorName, self.cursor))
 
     def update_cursor(self, newCursor):
         if newCursor != self.cursor:
-            plug.service_db.put('dropbox_cursor', newCursor)
+            plug.service_db.put(self.cursorName, newCursor)
             self.cursor = newCursor
-            plug.logger.debug("New cursor: '{}'".format(newCursor))
+            plug.logger.debug("New {} value: '{}'".format(self.cursorName,
+                                                          newCursor))
 
     def file_deletion_check(self, metadata, db_metadata):
         """Check if a file has been deleted on Dropbox
@@ -301,6 +308,7 @@ class CheckChanges(threading.Thread):
         elif metadata is None:
             plug.logger.debug(u"Unknown Dropbox file '{}' was deleted, skipped"
                               .format(db_metadata['path']))
+            deleted = True
         return deleted
 
     def file_update_check(self, metadata, db_metadata):
@@ -342,12 +350,7 @@ class CheckChanges(threading.Thread):
                                         value=True)
         if not filename:  # no conflict
             filename = db_path
-        # Strip the root in the Dropbox filename for root coherence.
-        prefix = self.prefix
-        if not prefix.startswith(u"/"):
-            prefix = u"/" + prefix
-        rootless_filename = filename[len(prefix):]
-        return rootless_filename
+        return filename
 
     def process_changes(self, changes):
         """The main change checking function of the thread.
@@ -366,17 +369,17 @@ class CheckChanges(threading.Thread):
             if db_metadata is None:
                 db_metadata = dropbox_client.metadata(db_filename)
             # Obtain the Onitu filename from the Dropbox one
-            rootless_filename = self.get_onitu_filename(
+            filename = self.get_onitu_filename(
                 db_metadata['path']
             )
             # ignore directories as onitu creates them on the fly
-            if self.is_a_folder(rootless_filename, db_metadata):
+            if self.is_a_folder(filename, db_metadata):
                 plug.logger.debug(u"{} is a folder - skipped"
                                   .format(db_metadata['path']))
                 continue
             plug.logger.debug(u"Getting metadata of file '{}'"
-                              .format(rootless_filename))
-            metadata = plug.get_metadata(rootless_filename)
+                              .format(filename))
+            metadata = plug.get_metadata(filename)
             # Do not check updates if the file has been deleted
             if self.file_deletion_check(metadata, db_metadata):
                 continue
@@ -389,19 +392,10 @@ class CheckChanges(threading.Thread):
         return changes['has_more']
 
     def check_dropbox(self):
-        # Check if the root has changed since last time. If that's the case,
-        # we must trash our cursor since it doesn't point to the same place
-        # anymore.
-        if plug.root != self.prefix:
-            self.prefix = plug.root
-            plug.logger.debug(u"Updating Dropbox root to '{}' folder"
-                              .format(self.prefix))
-            plug.service_db.put('root', self.prefix)
-            self.update_cursor(None)
-        # We must have a cursor in order to use longpoll_delta
         result = {}
+        # We must have a cursor in order to use longpoll_delta
         if self.cursor is not None:
-            plug.logger.debug(u"Longpolling Dropbox...")
+            plug.logger.debug("Longpolling Dropbox...")
             result = dropbox_client.longpoll_delta(cursor=self.cursor)
             if not result.get('changes', False):
                 plug.logger.debug("No changes, longpoll timeout")
@@ -426,7 +420,7 @@ class CheckChanges(threading.Thread):
         return backoff
 
     def run(self):
-        while not self.stop.isSet():
+        while not self.stopEvent.isSet():
             try:
                 backoff = self.check_dropbox()
             except urllib3.exceptions.MaxRetryError as mre:
@@ -437,10 +431,10 @@ class CheckChanges(threading.Thread):
                 return
             plug.logger.debug("Waiting {} seconds before longpolling again"
                               .format(backoff))
-            self.stop.wait(backoff)
+            self.stopEvent.wait(backoff)
 
     def stop(self):
-        self.stop.set()
+        self.stopEvent.set()
 
 
 def start(*args, **kwargs):
@@ -448,8 +442,12 @@ def start(*args, **kwargs):
         raise DriverError(
             "The change timer option must be a positive integer")
     connect_client()
-    # Start the watching-for-new-files thread
-    check = CheckChanges(plug.options['changes_timer'])
-    check.daemon = True
-    check.start()
+    # Start the watching-for-new-files threads
+    for folder in plug.folders_to_watch:
+        plug.logger.debug(u"Starting check change thread on folder {}"
+                          .format(folder.path))
+        check = CheckChanges(folder, plug.options['changes_timer'])
+        check.daemon = True
+        check.start()
+
     plug.listen()

--- a/drivers/dropbox/onitu_dropbox/tests/driver.py
+++ b/drivers/dropbox/onitu_dropbox/tests/driver.py
@@ -49,37 +49,37 @@ class Driver(driver.Driver):
             pass
 
     def mkdir(self, subdirs):
-        self.dropbox_client.file_create_folder(u(self.root + subdirs))
+        self.dropbox_client.file_create_folder(u(subdirs))
 
     def rmdir(self, path):
         self.unlink(path)
 
     def write(self, filename, content):
-        self.dropbox_client.put_file(u(self.root + filename), content)
+        self.dropbox_client.put_file(u(filename), content)
 
     def generate(self, filename, size):
         self.write(filename, os.urandom(size))
 
     def exists(self, filename):
         metadata = self.dropbox_client.metadata(
-            u(self.root + filename),
+            u(filename),
             include_deleted=True
         )
         return not metadata.get(u'is_deleted', False)
 
     def unlink(self, filename):
         # Dropbox needs bytes for file_delete, for god-knows-what reason
-        self.dropbox_client.file_delete(b(self.root + filename))
+        self.dropbox_client.file_delete(b(filename))
 
     def rename(self, source, target):
         # Same thing than for file_delete
         self.dropbox_client.file_move(
-            from_path=b(self.root + source),
-            to_path=b(self.root + target)
+            from_path=b(source),
+            to_path=b(target)
         )
 
     def checksum(self, filename):
-        data = self.dropbox_client.get_file(u(self.root + filename))
+        data = self.dropbox_client.get_file(u(filename))
         return hashlib.md5(data.read()).hexdigest()
 
 

--- a/drivers/hubic/README
+++ b/drivers/hubic/README
@@ -6,30 +6,54 @@ HUBIC account.
 
 How works the get_refresh_token.py script:
 
-Your web browser will be launched in order to let Onitu gain access to your Flickr account..
-Then, you will be redirected to a localhost address.
+Your web browser will be launched in order to let Onitu gain access to your Hubic account.
+You're going to need to input your Hubic credentials and then hit the "Accept" button.
+Then, you will be redirected to a localhost address saying a problem occurred.
+This is normal because you probably have no web server running on your machine.
 There is a parameter (in the url) named code.
-You will need to copy/paste it for the next part of this script.
+It is what you will need to copy/paste it for the next part of this script.
 
-The code parameter in the redirected url is after 'http://localhost/?code=' and before '&scope=...'
+The code parameter in the redirected url is after 'http://localhost/?code=' and before '&scope=...'.
 
-An example of setup.json file with hubic:
+Once you paste it back to the script in your terminal, it should exit after printing the refresh token you'll be able to use in your Onitu configuration.
 
-{
-  "name": "example",
 
-  "services": {
-        "hubic": {
-              "driver": "hubic",
-              "root": "/onitu_hubic",
-              "options": {
-                    "refresh_token": "THE TOKEN RETRIEVED WITH GET_REFRESH_TOKEN.PY",
-                    "changes_timer" : 60
-              }
-        },
-        "local": {
-              "root": "/onitu_local"
-              "driver": "local_storage",
-        }
-  }
-}
+Example
+=======
+
+An example of setup.yml configuration file set up with Hubic and Local Storage.
+
+This will synchronize the local folder "Music" in user eric's home with the folder
+eric/Music on your hubic account.
+
+"
+name: example
+
+folders:
+  music:
+    mimetypes:
+      - "audio/*"
+  docs:
+    blacklist:
+      - "*.bak"
+      - Private/
+  backup:
+    blacklist:
+      - ".*"
+    file_size:
+      max: 2G
+
+services:
+  A:
+    driver: local_storage
+    folders:
+      music: /home/eric/Music
+      docs: /home/eric/Docs
+  H:
+   driver: hubic
+   folders:
+     music: eric/Music
+   options:
+     refresh_token: PLACE_REFRESH_TOKEN_HERE
+     changes_timer: 10
+"

--- a/drivers/hubic/README
+++ b/drivers/hubic/README
@@ -9,9 +9,9 @@ How works the get_refresh_token.py script:
 Your web browser will be launched in order to let Onitu gain access to your Hubic account.
 You're going to need to input your Hubic credentials and then hit the "Accept" button.
 Then, you will be redirected to a localhost address saying a problem occurred.
-This is normal because you probably have no web server running on your machine.
+This is normal because you probably don't have a web server running on your machine.
 There is a parameter (in the url) named code.
-It is what you will need to copy/paste it for the next part of this script.
+It is what you will need to copy/paste for the next part of this script.
 
 The code parameter in the redirected url is after 'http://localhost/?code=' and before '&scope=...'.
 

--- a/drivers/hubic/get_refresh_token.py
+++ b/drivers/hubic/get_refresh_token.py
@@ -23,7 +23,7 @@ if __name__ == '__main__':
 
     print
     print "Your web browser will be launched in order to let Onitu gain "
-    "access to your Hubic account.."
+    "access to your Hubic account."
     print "Then, you will be redirected to a localhost address."
     print "There is a parameter (in the url) named \"code\"."
     print "You will need to copy/paste it for the next part of this script."
@@ -61,6 +61,6 @@ if __name__ == '__main__':
     hubic_refresh_token = response.json()["refresh_token"]
 
     print
-    print "You can now copy the following refresh token in setup.json"
+    print "You can now copy the following refresh token in setup.yml"
     print hubic_refresh_token
     print

--- a/drivers/hubic/onitu_hubic/hubic.py
+++ b/drivers/hubic/onitu_hubic/hubic.py
@@ -1,7 +1,7 @@
 import base64
-import os
 import requests
 import hashlib
+import os
 import threading
 import time
 import datetime
@@ -110,7 +110,7 @@ class Hubic:
         return res.headers
 
 
-########################### ONITU HANDLERS ###################################
+# ######################### ONITU HANDLERS ###################################
 
 @plug.handler()
 def set_chunk_size(chunk_size):

--- a/drivers/hubic/onitu_hubic/hubic.py
+++ b/drivers/hubic/onitu_hubic/hubic.py
@@ -1,7 +1,6 @@
 import base64
 import requests
 import hashlib
-import os
 import threading
 import time
 import datetime

--- a/drivers/local_storage/onitu_local_storage/local_storage.py
+++ b/drivers/local_storage/onitu_local_storage/local_storage.py
@@ -278,10 +278,18 @@ else:
         def process_IN_MOVED_TO(self, event):
             if event.dir:
                 for new in walkfiles(event.pathname):
-                    old = new.replace(event.pathname, event.src_pathname)
-                    self.process_event(old, move, u(new))
+                    if hasattr(event, 'src_pathname'):
+                        old = new.replace(event.pathname, event.src_pathname)
+                        self.process_event(old, move, u(new))
+                    else:
+                        self.process_event(new, update)
             else:
-                self.process_event(event.src_pathname, move, u(event.pathname))
+                if hasattr(event, 'src_pathname'):
+                    self.process_event(
+                        event.src_pathname, move, u(event.pathname)
+                    )
+                else:
+                    self.process_event(event.pathname, update)
 
         def process_event(self, filename, callback, *args):
             filename = os.path.relpath(u(filename), self.folder.path)

--- a/drivers/local_storage/onitu_local_storage/local_storage.py
+++ b/drivers/local_storage/onitu_local_storage/local_storage.py
@@ -53,6 +53,9 @@ def delete(metadata):
 def move(old_metadata, new_filename):
     new_metadata = plug.move_file(old_metadata, new_filename)
     new_metadata.extra['revision'] = os.path.getmtime(new_filename)
+    # We update the size in case the file was moved very quickly after a change
+    # so the old metadata are not up-to-date
+    new_metadata.size = os.path.getsize(new_metadata.path)
     new_metadata.write()
 
 

--- a/drivers/local_storage/onitu_local_storage/local_storage.py
+++ b/drivers/local_storage/onitu_local_storage/local_storage.py
@@ -2,7 +2,7 @@ import os
 
 from onitu.plug import Plug, DriverError, ServiceError
 from onitu.escalator.client import EscalatorClosed
-from onitu.utils import IS_WINDOWS, u
+from onitu.utils import IS_WINDOWS, u, log_traceback
 
 if IS_WINDOWS:
     import threading
@@ -301,7 +301,13 @@ else:
                 metadata = plug.get_metadata(filename, self.folder)
                 callback(metadata, *args)
             except EscalatorClosed:
-                return
+                pass
+            except OSError as e:
+                plug.logger.error("Error when dealing with FS event: {}", e)
+            except (DriverError, ServiceError) as e:
+                plug.logger.error(str(e))
+            except Exception:
+                log_traceback(plug.logger)
 
     def watch_changes(folder):
         manager = pyinotify.WatchManager()

--- a/drivers/local_storage/onitu_local_storage/local_storage.py
+++ b/drivers/local_storage/onitu_local_storage/local_storage.py
@@ -61,9 +61,11 @@ def check_changes(folder):
 
     expected_files.update(plug.list(folder).keys())
 
-    for filename in walkfiles(folder.path):
-        if os.path.splitext(filename)[1] == TMP_EXT:
+    for path in walkfiles(folder.path):
+        if os.path.splitext(path)[1] == TMP_EXT:
             continue
+
+        filename = folder.relpath(path)
 
         expected_files.discard(filename)
 
@@ -71,7 +73,7 @@ def check_changes(folder):
         revision = metadata.extra.get('revision', 0.)
 
         try:
-            mtime = os.path.getmtime(filename)
+            mtime = os.path.getmtime(path)
         except (IOError, OSError) as e:
             raise ServiceError(
                 u"Error updating file '{}': {}".format(metadata.path, e)

--- a/drivers/local_storage/onitu_local_storage/tests/__init__.py
+++ b/drivers/local_storage/onitu_local_storage/tests/__init__.py
@@ -1,3 +1,4 @@
 from .driver import Driver, DriverFeatures
+from . import driver_tests
 
-__all__ = ["Driver", "DriverFeatures"]
+__all__ = ["Driver", "DriverFeatures", "driver_tests"]

--- a/drivers/local_storage/onitu_local_storage/tests/driver.py
+++ b/drivers/local_storage/onitu_local_storage/tests/driver.py
@@ -3,8 +3,6 @@ import shutil
 import hashlib
 import tempfile
 
-from path import path
-
 from tests.utils import driver
 
 
@@ -12,7 +10,7 @@ class Driver(driver.Driver):
     SPEED_BUMP = 1
 
     def __init__(self, *args, **options):
-        self._root = path(tempfile.mkdtemp())
+        self._root = tempfile.mkdtemp()
         super(Driver, self).__init__('local_storage',
                                      *args,
                                      **options)
@@ -22,10 +20,13 @@ class Driver(driver.Driver):
         return self._root
 
     def close(self):
-        self.root.rmtree('.')
+        shutil.rmtree(self.root)
 
     def mkdir(self, subdirs):
-        (self.root / subdirs).makedirs_p()
+        try:
+            os.makedirs(os.path.join(self.root, subdirs))
+        except OSError:
+            pass
 
         # Give some time to inotify in order
         # to avoid a known bug where new files
@@ -36,26 +37,28 @@ class Driver(driver.Driver):
         time.sleep(0.1)
 
     def rmdir(self, path):
-        shutil.rmtree(self.root / path)
+        shutil.rmtree(os.path.join(self.root, path))
 
     def write(self, filename, content):
-        with open(self.root / filename, 'w+') as f:
+        with open(os.path.join(self.root, filename), 'w+') as f:
             f.write(content)
 
     def generate(self, filename, size):
         self.write(filename, os.urandom(size))
 
     def exists(self, filename):
-        return os.path.exists(self.root / filename)
+        return os.path.exists(os.path.join(self.root, filename))
 
     def unlink(self, filename):
-        return os.unlink(self.root / filename)
+        return os.unlink(os.path.join(self.root, filename))
 
     def rename(self, source, target):
-        return os.rename(self.root / source, self.root / target)
+        return os.renames(
+            os.path.join(self.root, source), os.path.join(self.root, target)
+        )
 
     def checksum(self, filename):
-        with open(self.root / filename) as f:
+        with open(os.path.join(self.root, filename)) as f:
             return hashlib.md5(f.read()).hexdigest()
 
 

--- a/drivers/local_storage/onitu_local_storage/tests/driver_tests.py
+++ b/drivers/local_storage/onitu_local_storage/tests/driver_tests.py
@@ -1,13 +1,13 @@
 import pytest
 
 from tests.utils.testdriver import TestDriver
-from tests.utils.loop import CounterLoop
+from tests.utils.loop import CounterLoop, BooleanLoop
 
 from . import Driver
 
 
 def get_services():
-    return Driver('rep1'), TestDriver('rep2')
+    return Driver('rep1'), TestDriver('rep2', speed_bump=1)
 
 
 @pytest.fixture(autouse=True)
@@ -15,7 +15,7 @@ def _(module_launcher_launch):
     pass
 
 
-def test_driver_move_file_not_watched(module_launcher):
+def test_move_file_not_watched(module_launcher):
     d_target, d_test = module_launcher.get_services('rep1', 'rep2')
     d_target.generate('to_move1', 10)
 
@@ -27,7 +27,7 @@ def test_driver_move_file_not_watched(module_launcher):
     loop.run(5)
 
 
-def test_driver_move_dir_not_watched(module_launcher):
+def test_move_dir_not_watched(module_launcher):
     d_target, d_test = module_launcher.get_services('rep1', 'rep2')
     d_target.mkdir('to_move2')
     d_target.generate('to_move2/foo', 10)
@@ -46,3 +46,60 @@ def test_driver_move_dir_not_watched(module_launcher):
     )
     d_target.rename('to_move2', d_target.path('default', 'moved2'))
     loop.run(5)
+
+
+def test_create_and_move_file(module_launcher):
+    d_target, d_test = module_launcher.get_services('rep1', 'rep2')
+
+    loop = BooleanLoop()
+    module_launcher.on_move_completed(
+        loop.stop, driver=d_test, src='to_move3', dest='moved3'
+    )
+    module_launcher.on_transfer_ended(
+        loop.stop, d_from=d_target, d_to=d_test, filename='moved3'
+    )
+
+    d_target.generate(d_target.path('default', 'to_move3'), 100)
+    d_target.rename(
+        d_target.path('default', 'to_move3'),
+        d_target.path('default', 'moved3')
+    )
+
+    loop.run(5)
+
+    assert not d_test.exists(d_test.path('default', 'to_move3'))
+    assert d_test.exists(d_test.path('default', 'moved3'))
+    assert d_target.checksum(d_target.path('default', 'moved3')) == \
+        d_test.checksum(d_test.path('default', 'moved3'))
+
+
+def test_create_and_move_file_during_transfer(module_launcher):
+    d_target, d_test = module_launcher.get_services('rep1', 'rep2')
+
+    loop = BooleanLoop()
+    module_launcher.on_move_completed(
+        loop.stop, driver=d_test, src='to_move3', dest='moved3'
+    )
+    module_launcher.on_transfer_ended(
+        loop.stop, d_from=d_target, d_to=d_test, filename='moved3'
+    )
+
+    intermediate_loop = BooleanLoop()
+    module_launcher.on_transfer_started(
+        intermediate_loop.stop, d_from=d_target, d_to=d_test,
+        filename='to_move3'
+    )
+
+    d_target.generate(d_target.path('default', 'to_move3'), 100)
+    intermediate_loop.run(2)
+    d_target.rename(
+        d_target.path('default', 'to_move3'),
+        d_target.path('default', 'moved3')
+    )
+
+    loop.run(5)
+
+    assert not d_test.exists(d_test.path('default', 'to_move3'))
+    assert d_test.exists(d_test.path('default', 'moved3'))
+    assert d_target.checksum(d_target.path('default', 'moved3')) == \
+        d_test.checksum(d_test.path('default', 'moved3'))

--- a/drivers/local_storage/onitu_local_storage/tests/driver_tests.py
+++ b/drivers/local_storage/onitu_local_storage/tests/driver_tests.py
@@ -1,0 +1,48 @@
+import pytest
+
+from tests.utils.testdriver import TestDriver
+from tests.utils.loop import CounterLoop
+
+from . import Driver
+
+
+def get_services():
+    return Driver('rep1'), TestDriver('rep2')
+
+
+@pytest.fixture(autouse=True)
+def _(module_launcher_launch):
+    pass
+
+
+def test_driver_move_file_not_watched(module_launcher):
+    d_target, d_test = module_launcher.get_services('rep1', 'rep2')
+    d_target.generate('to_move1', 10)
+
+    loop = CounterLoop(1)
+    module_launcher.on_transfer_ended(
+        loop.check, d_from=d_target, d_to=d_test, filename='moved1'
+    )
+    d_target.rename('to_move1', d_target.path('default', 'moved1'))
+    loop.run(5)
+
+
+def test_driver_move_dir_not_watched(module_launcher):
+    d_target, d_test = module_launcher.get_services('rep1', 'rep2')
+    d_target.mkdir('to_move2')
+    d_target.generate('to_move2/foo', 10)
+    d_target.generate('to_move2/bar', 10)
+    d_target.generate('to_move2/lol', 10)
+
+    loop = CounterLoop(3)
+    module_launcher.on_transfer_ended(
+        loop.check, d_from=d_target, d_to=d_test, filename='moved2/foo'
+    )
+    module_launcher.on_transfer_ended(
+        loop.check, d_from=d_target, d_to=d_test, filename='moved2/bar'
+    )
+    module_launcher.on_transfer_ended(
+        loop.check, d_from=d_target, d_to=d_test, filename='moved2/lol'
+    )
+    d_target.rename('to_move2', d_target.path('default', 'moved2'))
+    loop.run(5)

--- a/drivers/local_storage/setup.py
+++ b/drivers/local_storage/setup.py
@@ -1,7 +1,7 @@
 import sys
 from setuptools import setup, find_packages
 
-install_requires = ["path.py"]
+install_requires = []
 
 if sys.platform.startswith('linux'):
     install_requires.append('pyinotify')

--- a/onitu/__main__.py
+++ b/onitu/__main__.py
@@ -65,6 +65,9 @@ def start_setup(*args, **kwargs):
     with escalator.write_batch() as batch:
         # TODO: handle folders from previous run
         for name, options in setup.get('folders', {}).items():
+            if options is None:
+                options = {}
+
             batch.put(u'folder:{}'.format(name), options)
 
     services = setup.get('services', {})
@@ -95,10 +98,9 @@ def load_service(escalator, service, conf):
     escalator.put(u'service:{}:driver'.format(service), conf['driver'])
     escalator.put(u'service:{}:root'.format(service), conf.get('root', ''))
 
-    if 'options' in conf:
-        escalator.put(
-            u'service:{}:options'.format(service), conf['options']
-        )
+    escalator.put(
+        u'service:{}:options'.format(service), conf.get('options', {})
+    )
 
     folders = conf.get('folders', {})
     escalator.put(u'service:{}:folders'.format(service), list(folders.keys()))

--- a/onitu/__main__.py
+++ b/onitu/__main__.py
@@ -96,7 +96,6 @@ def load_service(escalator, service, conf):
         return
 
     escalator.put(u'service:{}:driver'.format(service), conf['driver'])
-    escalator.put(u'service:{}:root'.format(service), conf.get('root', ''))
 
     escalator.put(
         u'service:{}:options'.format(service), conf.get('options', {})

--- a/onitu/plug/dealer.py
+++ b/onitu/plug/dealer.py
@@ -8,6 +8,7 @@ from multiprocessing.pool import ThreadPool
 from logbook import Logger
 
 from onitu.utils import get_events_uri, b, log_traceback
+from onitu.escalator.client import EscalatorClosed
 
 from .workers import WORKERS, UP
 
@@ -54,6 +55,8 @@ class Dealer(object):
             self.logger.info("Started")
 
             self.listen(listener)
+        except EscalatorClosed:
+            pass
         except Exception:
             log_traceback(self.logger)
         finally:

--- a/onitu/plug/folder.py
+++ b/onitu/plug/folder.py
@@ -1,4 +1,4 @@
-import os
+from .exceptions import DriverError
 
 
 class Folder(object):
@@ -35,10 +35,16 @@ class Folder(object):
         return cls(folder, path, options)
 
     def relpath(self, filename):
-        return os.path.relpath(filename, self.path)
+        if not filename.startswith(self.path):
+            raise DriverError(
+                u"'{}' is not in the folder {}".format(filename, self.name)
+            )
+        return filename[len(self.path):].lstrip('/')
 
     def join(self, filename):
-        return os.path.join(self.path, filename)
+        if filename.startswith(self.path):
+            filename = filename[len(self.path):]
+        return self.path.rstrip('/') + '/' + filename.lstrip('/')
 
     def contains(self, filename):
         return filename != self.path and filename.startswith(self.path)

--- a/onitu/plug/folder.py
+++ b/onitu/plug/folder.py
@@ -12,20 +12,27 @@ class Folder(object):
         return self.name
 
     @classmethod
-    def get_folders(cls, escalator, service):
+    def get_folders(cls, plug):
         folders = {}
-        for name in escalator.get(u'service:{}:folders'.format(service),
-                                  default=[]):
-            folders[name] = cls.get(escalator, service, name)
+        names = plug.escalator.get(u'service:{}:folders'.format(plug.name),
+                                   default=())
+        for folder in names:
+            folders[folder] = cls.get(plug, folder)
+
         return folders
 
     @classmethod
-    def get(cls, escalator, service, name):
-        prefix = u'service:{}:folder:{}'.format(service, name)
-        path = escalator.get(u'{}:path'.format(prefix), default="")
-        options = escalator.get(u'{}:options'.format(prefix), default={})
+    def get(cls, plug, folder):
+        prefix = u'service:{}:folder:{}'.format(plug.name, folder)
+        path = plug.escalator.get(u'{}:path'.format(prefix), default="")
+        options = plug.escalator.get(u'{}:options'.format(prefix), default={})
 
-        return cls(name, path, options)
+        normalized_path = plug.call('normalize_path', path)
+
+        if normalized_path is not None:
+            path = normalized_path
+
+        return cls(folder, path, options)
 
     def relpath(self, filename):
         return os.path.relpath(filename, self.path)

--- a/onitu/plug/folder.py
+++ b/onitu/plug/folder.py
@@ -41,4 +41,4 @@ class Folder(object):
         return os.path.join(self.path, filename)
 
     def contains(self, filename):
-        return filename.startswith(self.path)
+        return filename != self.path and filename.startswith(self.path)

--- a/onitu/plug/metadata.py
+++ b/onitu/plug/metadata.py
@@ -1,5 +1,3 @@
-import os
-
 from onitu.utils import get_fid, get_mimetype, u
 
 from .folder import Folder
@@ -95,9 +93,6 @@ class Metadata(object):
     @property
     def path(self):
         if not self._path:
-            self._path = os.path.join(
-                self.plug.root, self.folder.path, self.filename
-            )
 
         return self._path
 

--- a/onitu/plug/metadata.py
+++ b/onitu/plug/metadata.py
@@ -43,7 +43,7 @@ class Metadata(object):
         self.mimetype = mimetype
 
         if folder_name and not folder:
-            folder = Folder.get(plug.escalator, plug.name, folder_name)
+            folder = Folder.get(plug, folder_name)
         elif folder and not folder_name:
             folder_name = folder.name
 
@@ -93,6 +93,7 @@ class Metadata(object):
     @property
     def path(self):
         if not self._path:
+            self._path = self.folder.join(self.filename)
 
         return self._path
 

--- a/onitu/plug/plug.py
+++ b/onitu/plug/plug.py
@@ -63,10 +63,6 @@ class Plug(object):
         self.publisher = self.context.socket(zmq.PUSH)
         self.publisher.connect(get_events_uri(session, 'referee'))
 
-        self.root = self.escalator.get(
-            u'service:{}:root'.format(name), default=''
-        )
-
         self.options = self.escalator.get(
             u'service:{}:options'.format(name), default={}
         )

--- a/onitu/plug/plug.py
+++ b/onitu/plug/plug.py
@@ -235,6 +235,12 @@ class Plug(object):
         return {filename.replace(prefix, '', 1): fid
                 for filename, fid in self.escalator.range(prefix)}
 
+    def exists(self, folder, path):
+        """
+        Return whether the given path exists in the folder or not.
+        """
+        return self.escalator.exists(u'path:{}:{}'.format(folder, path))
+
     def validate_options(self, manifest):
         """
         Validate the options and set the default values using informations

--- a/onitu/plug/plug.py
+++ b/onitu/plug/plug.py
@@ -67,7 +67,7 @@ class Plug(object):
             u'service:{}:options'.format(name), default={}
         )
 
-        self.folders = Folder.get_folders(self.escalator, self.name)
+        self.folders = Folder.get_folders(self)
 
         self.validate_options(manifest)
 

--- a/onitu/plug/plug.py
+++ b/onitu/plug/plug.py
@@ -359,3 +359,13 @@ class Plug(object):
             prefix = u'service:{}:db:'.format(self.name)
             self._service_db = self.escalator.clone(prefix=prefix)
         return self._service_db
+
+    @property
+    def folders_to_watch(self):
+        """
+        Return the list of the folders which should be watched by the driver
+        """
+        return tuple(
+            folder for folder in self.folders.values()
+            if not any(f.contains(folder.path) for f in self.folders.values())
+        )

--- a/onitu/plug/workers.py
+++ b/onitu/plug/workers.py
@@ -224,8 +224,10 @@ class MoveWorker(Worker):
 
         self.logger.debug("Moving '{}' to '{}'", self.filename, new_filename)
 
+        is_uptodate = self.dealer.name in self.metadata.uptodate
+
         try:
-            if 'move_file' in self.dealer.plug._handlers:
+            if 'move_file' in self.dealer.plug._handlers and is_uptodate:
                 self.call('move_file', self.metadata, new_metadata)
                 self.metadata.delete()
             else:

--- a/onitu/plug/workers.py
+++ b/onitu/plug/workers.py
@@ -66,6 +66,7 @@ class TransferWorker(Worker):
 
     def do(self):
         success = False
+        dealer = None
 
         try:
             self.start_transfer()
@@ -80,7 +81,8 @@ class TransferWorker(Worker):
         else:
             success = True
         finally:
-            dealer.close()
+            if dealer:
+                dealer.close()
 
         self.end_transfer(success)
 

--- a/onitu/referee/referee.py
+++ b/onitu/referee/referee.py
@@ -69,6 +69,8 @@ class Referee(object):
                 raise
         except EscalatorClosed:
             pass
+        except Exception:
+            log_traceback(self.logger)
         finally:
             if listener:
                 listener.close()
@@ -83,8 +85,6 @@ class Referee(object):
                     if cmd in self.handlers:
                         fid = key.split(':')[-1]
                         self.handlers[cmd](fid, *args[1:])
-                except Exception:
-                    log_traceback(self.logger)
                 finally:
                     self.escalator.delete(key)
 

--- a/onitu/service/__main__.py
+++ b/onitu/service/__main__.py
@@ -8,6 +8,7 @@ from logbook.queues import ZeroMQHandler
 from onitu.utils import at_exit, get_available_drivers, get_logs_uri, u
 from onitu.utils import log_traceback
 from onitu.escalator.client import EscalatorClosed
+from onitu.plug.exceptions import AbortOperation
 
 session = u(sys.argv[1])
 driver_name = sys.argv[2]
@@ -72,6 +73,8 @@ with ZeroMQHandler(get_logs_uri(session), multi=True).applicationbound():
 
         while thread.is_alive():
             thread.join(100)
+    except AbortOperation:
+        error("Closing service {} due to an error.", name)
     except Exception:
         log_traceback()
 

--- a/setup.yml
+++ b/setup.yml
@@ -2,7 +2,7 @@ name: example
 
 folders:
   music:
-    type:
+    mimetypes:
       - "audio/*"
   docs:
     blacklist:

--- a/setup.yml
+++ b/setup.yml
@@ -3,33 +3,36 @@ name: example
 folders:
   music:
     type:
-      - audio/
+      - "audio/*"
   docs:
     blacklist:
       - "*.bak"
       - Private/
   backup:
+    blacklist:
+      - ".*"
     file_size:
       max: 2G
 
 services:
   A:
     driver: local_storage
-    root: example/service_a
     folders:
-      music: Music
-      docs: Docs
+      music: ~/Music
+      docs: ~/Docs
       backup:
+        path: ~/
         mode: ro
   B:
     driver: local_storage
-    root: example/service_b
     folders:
+      music: ~/My Music
+      docs: ~/My Documents
       backup:
+        path: ~/
         mode: ro
   C:
     driver: local_storage
-    root: example/service_c
     folders:
       backup:
         path: backup

--- a/tests/utils/driver.py
+++ b/tests/utils/driver.py
@@ -25,6 +25,15 @@ class Driver(object):
             folders = {'default': 'default_' + get_random_string(5)}
         self.folders = folders
 
+        if hasattr(self, 'root'):
+            root = self.root.rstrip('/')
+
+            for name, folder in self.folders.items():
+                if isinstance(folder, dict):
+                    folder['path'] = root + '/' + folder['path']
+                else:
+                    self.folders[name] = root + '/' + folder
+
         if speed_bump and self.SPEED_BUMP > 0:
             self.options['chunk_size'] = self.SPEED_BUMP
 
@@ -37,7 +46,6 @@ class Driver(object):
     def dump(self):
         return {
             'driver': self.type,
-            'root': self.root,
             'options': self.options,
             'folders': self.folders
         }

--- a/tests/utils/test_driver/onitu_test_driver/tests/driver.py
+++ b/tests/utils/test_driver/onitu_test_driver/tests/driver.py
@@ -14,10 +14,6 @@ class Driver(driver.Driver):
         self.req_socket = self.context.socket(zmq.REQ)
         self.notif_socket = self.context.socket(zmq.PUSH)
 
-    @property
-    def root(self):
-        return ''
-
     def connect(self, session):
         self.session = session
         self.req_socket.connect(self.get_uri('requests'))


### PR DESCRIPTION
The main changes for the drivers are the following:
- Instead of watching the root, the drivers should watch each folder returned by `Plug.folders_to_watch`. Note that the returned folders are objects (`onitu.plug.folder.Folder`) which have a `path` property returning its absolute path.
- Each folders has an absolute path, no need to concatenate it anymore. `metadata.path` returns an absolute path and `plug.get_metadata` takes a path relative to the folder
- `plug.get_metadata` should always be called with the folder from which the update is (`plug.get_metadata(relative_path, folder)`)
- If necessary, the drivers can normalize the path of each folder via the `normalize_path` handler. This is used by Local Storage to convert the `~` for instance.

Status:
- [x] Remove the root from the Plug
- [x] Use absolute paths for the folders
- [x] Adapt the drivers:
  - [x] Local Storage
  - [x] Hubic
  - [x] S3
  - [x] Dropbox
