### PR TITLE
Authentication for the API.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,9 @@ setup(
         "plyvel",
         "pyyaml",
         "msgpack-python",
-        "bottle"
+        "bottle",
+        "PyJWT",
+        "passlib"
     ],
     extras_require={
         'dev': ['flake8', 'tox'],

--- a/setup.yml
+++ b/setup.yml
@@ -1,5 +1,23 @@
 name: example
 
+api:
+  host: localhost
+  port: 3862
+
+users:
+
+  # Generate passhash like this:
+  # python -c 'import passlib.hash; print(passlib.hash.sha256_crypt.encrypt("bar"))'
+  # python -c 'import passlib.hash; print(passlib.hash.sha256_crypt.encrypt("eggs"))'
+
+  foo:
+    passhash: '$5$rounds=110000$m9wWP.4MAF4my6i9$i1cDs9zfFrm7.0BHDslJDeJBDkhoCet4F/Fd6913pqD'
+    roles: user, admin
+
+  spam:
+    passhash: '$5$rounds=110000$fVxj3yfUG4v4JWUs$IOAg2L7Inzi1B9NAZPzZyBFEt8Q0HLXLeTIcnoUcH6A'
+    roles: user
+
 folders:
   music:
     mimetypes:

--- a/tests/utils/setup.py
+++ b/tests/utils/setup.py
@@ -1,6 +1,7 @@
 import os
 import json
 import shutil
+from passlib.hash import sha256_crypt as passwordhash
 
 from onitu.utils import TMPDIR, b, get_random_string
 
@@ -8,11 +9,19 @@ from .launcher import Launcher
 
 
 class Setup(object):
-    def __init__(self, folders=None):
+    def __init__(self, folders=None, api=None, users=None):
         self.services = {}
         if folders is None:
             folders = {}
         self.folders = folders
+
+        if api is None:
+            api = {"host": "localhost", "port": 3862}
+        self.api = api
+
+        if users is None:
+            users = {}
+        self.users = users
 
         self._json = None
 
@@ -32,6 +41,10 @@ class Setup(object):
 
         return self
 
+    def add_user(self, user, pwd, roles):
+        self.users[user] = {"passhash": passwordhash.encrypt(pwd),
+                            "roles": roles}
+
     def clean(self, services=True):
         if services:
             for service in self.services.values():
@@ -46,6 +59,8 @@ class Setup(object):
             setup['name'] = self.name
         setup['services'] = {name: e.dump for name, e in self.services.items()}
         setup['folders'] = self.folders
+        setup['api'] = self.api
+        setup['users'] = self.users
         return setup
 
     @property


### PR DESCRIPTION
This adds a `@auth` decorator that can be used in the API to protect requests. The users are stored in the setup.yml file. Authentication is done using a signed JWT cookie. Basic-Auth is also supported.

This also adds `OPTIONS` as a valid method that does nothing on all requests because this is needed for CORS. Most browsers perform an `OPTIONS`  request as a pre-flight.
